### PR TITLE
Fix link to The 'Mixing Secrets' Free Multitrack Download Library

### DIFF
--- a/content/datasets/dsd100.md
+++ b/content/datasets/dsd100.md
@@ -8,7 +8,7 @@ _dsd100_ contains two folders, a folder with a training set: "train", composed o
 
 For each file, the mixture correspond to the sum of all the signals. All signals are stereophonic and encoded at 44.1kHz.
 
-The data from _dsd100_ consist of 100 tracks which are derived from [The 'Mixing Secrets' Free Multitrack Download Library](www.cambridge-mt.com/ms-mtk.htm). Please refer to this original resource for any question regarding your rights on your use of the DSD100 data.
+The data from _dsd100_ consist of 100 tracks which are derived from [The 'Mixing Secrets' Free Multitrack Download Library](http://www.cambridge-mt.com/ms/mtk/). Please refer to this original resource for any question regarding your rights on your use of the DSD100 data.
 
 Have a look at the [detailed list of all tracks](https://www.sisec17.audiolabs-erlangen.de/#/dataset).
 


### PR DESCRIPTION
Came across this while checking out the project. This PR fixes a broken external link by adding a missing http scheme (without it, the link resolves to the current domain, resulting in a [404](https://sigsep.github.io/datasets/www.cambridge-mt.com/ms-mtk.htm)). It also updates the URL to use the path resolved by the server when navigating to the page.