### PR TITLE
Update musdb.md - Broken link for Mixing secrets

### DIFF
--- a/content/datasets/musdb.md
+++ b/content/datasets/musdb.md
@@ -9,7 +9,7 @@ _musdb18_ contains two folders, a folder with a training set: "train", composed 
 All signals are stereophonic and encoded at 44.1kHz.
 
 The data from _musdb18_ is composed of several different sources:
-* 100 tracks are taken from the [DSD100 dataset](dsd100.md), which is itself derived from [The 'Mixing Secrets' Free Multitrack Download Library](www.cambridge-mt.com/ms-mtk.htm). Please refer to this original resource for any question regarding your rights on your use of the DSD100 data.
+* 100 tracks are taken from the [DSD100 dataset](dsd100.md), which is itself derived from [The 'Mixing Secrets' Free Multitrack Download Library](https://www.cambridge-mt.com/ms/mtk/). Please refer to this original resource for any question regarding your rights on your use of the DSD100 data.
 * 46 tracks are taken from [the MedleyDB](http://medleydb.weebly.com) licensed under Creative Commons (BY-NC-SA 4.0).
 * 2 tracks were kindly provided by Native Instruments originally part of [their stems pack](https://www.native-instruments.com/en/specials/stems-for-all/free-stems-tracks/).
 * 2 tracks are from the Canadian rock band The Easton Ellises as part of the [heise stems remix competition](https://www.heise.de/ct/artikel/c-t-Remix-Wettbewerb-The-Easton-Ellises-2542427.html#englisch), licensed under Creative Commons (BY-NC-SA 3.0).


### PR DESCRIPTION
Broken link for Mixing secrets. Correct one taken from the DSD100 page https://www.cambridge-mt.com/ms/mtk/